### PR TITLE
fix compatibility with xknx v3.15.0

### DIFF
--- a/knx-lens-logger.py
+++ b/knx-lens-logger.py
@@ -281,9 +281,6 @@ async def start_logger_mode():
 
     xknx = XKNX(connection_config=connection_config, daemon_mode=True)
     
-    if knx_project:
-        xknx.knxproj = knx_project
-        
     if knx_project is not None:
         dpt_dict = {
             ga: data["dpt"]
@@ -343,3 +340,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
attribute 'knxproj' seems to never be used but trying to set it breaks compatibility with newer xknx versions

fixes #40 